### PR TITLE
Add chmod +x docker.sh for execution permission

### DIFF
--- a/examples/generate_job_python.bash
+++ b/examples/generate_job_python.bash
@@ -71,6 +71,7 @@ cp $rootpath/python/edna/setup.cfg .
 # Build the docker image and delete the generated sh file
 colored_print "Building the docker image"
 $rootpath/$2/bin/j2 $rootpath/examples/docker.sh.j2 config.yaml > docker.sh
+chmod +x docker.sh
 ./docker.sh
 colored_print "Deleting docker.sh and associated detritus"
 rm docker.sh


### PR DESCRIPTION
The current script sometimes fails because the generated docker.sh file does not have permission to execute. This change would add `chmod +x docker.sh` so that the permission always gets added before we attempt to execute the file.