### PR TITLE
Added a configuration option to the EdnaJob Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # EDNA
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue)](https://opensource.org/licenses/Apache-2.0)
+[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/asuprem/edna)](https://github.com/asuprem/edna/releases)
+[![Docs](https://img.shields.io/badge/docs-pdoc-brightgreen)](https://asuprem.github.io/edna/)
+
 EDNA is an end-to-end streaming toolkit for ingesting, processing, and emitting streaming data. It is based on our prior work with [LITMUS](https://ieeexplore.ieee.org/abstract/document/6971222),
 [ASSED](https://dl.acm.org/doi/abs/10.1145/3328905.3329510), and [EventMapper](https://arxiv.org/abs/2001.08700) and incorporates a slew of improvements and features for streaming analytics, fault tolerance, and end-to-end management.
 

--- a/controller/controller/pom.xml
+++ b/controller/controller/pom.xml
@@ -95,6 +95,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.78</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-jaxb-annotations</artifactId>
             <version>2.9.8</version>
@@ -157,6 +163,31 @@
             <configuration>
                 <mainClass>edu.graitdm.ednajobcontroller.controller.Main</mainClass>
             </configuration>
+        </plugin>
+
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+            <version>2.4.1</version>
+            <configuration>
+                <descriptorRefs>
+                    <descriptorRef>jar-with-dependencies</descriptorRef>
+                </descriptorRefs>
+                <archive>
+                    <manifest>
+                        <mainClass>edu.graitdm.ednajobcontroller.controller.Main</mainClass>
+                    </manifest>
+                </archive>
+            </configuration>
+            <executions>
+                <execution>
+                    <id>make-assembly</id>
+                    <phase>package</phase>
+                    <goals>
+                        <goal>single</goal>
+                    </goals>
+                </execution>
+            </executions>
         </plugin>
     </plugins>
     </build>

--- a/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/configuration/BaseConfiguration.java
+++ b/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/configuration/BaseConfiguration.java
@@ -1,0 +1,55 @@
+package edu.graitdm.ednajobcontroller.configuration;
+
+
+import com.beust.jcommander.Parameter;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static edu.graitdm.ednajobcontroller.configuration.IConfigurationDefaults.EDNA_JOB_PATHS;
+import static edu.graitdm.ednajobcontroller.configuration.IConfigurationDefaults.EDNA_NAMESPACE;
+import static edu.graitdm.ednajobcontroller.configuration.IConfigurationDefaults.KUBECTL_HOST;
+import static edu.graitdm.ednajobcontroller.configuration.IConfigurationDefaults.KUBECTL_PORT;
+import static edu.graitdm.ednajobcontroller.configuration.IConfigurationDefaults.KUBECTL_PROTOCOL;
+
+public class BaseConfiguration {
+    @Parameter
+    private List<String> parameters = new ArrayList<>();
+
+    @Parameter(names = "--kubectl-protocol", description = "Access protocol for kubectl proxy. Either `http` or `https`")
+    @Getter @Setter private String kubectlProtocol;
+
+    @Parameter(names = "--kubectl-host", description = "The kubectl proxy host. Default is `127.0.0.1`.")
+    @Getter @Setter private String kubectlHost;
+
+    @Parameter(names = "--kubectl-port", description = "The kubectl proxy port. Default is `8080`.")
+    @Getter @Setter private String kubectlPort;
+
+    @Parameter(names = "--edna-job-path", description = "Location for edna application and job executables.")
+    @Getter @Setter private String ednaJobPaths;
+
+    @Parameter(names = "--edna-namespace", description = "Location for edna application and job executables.")
+    @Getter @Setter private String ednaNamespace;
+
+    private String kubectlURL;
+
+    public BaseConfiguration(){
+        kubectlProtocol = KUBECTL_PROTOCOL;
+        kubectlHost = KUBECTL_HOST;
+        kubectlPort = KUBECTL_PORT;
+        ednaJobPaths = EDNA_JOB_PATHS;
+        ednaNamespace = EDNA_NAMESPACE;
+        buildURL();
+    }
+
+    public String getKubectlURL(){
+        buildURL();
+        return kubectlURL;
+    }
+    private void buildURL(){
+        kubectlURL = getKubectlProtocol() + "://" + getKubectlHost() + ":" + getKubectlPort();
+    }
+
+}

--- a/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/configuration/IConfigurationDefaults.java
+++ b/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/configuration/IConfigurationDefaults.java
@@ -1,0 +1,10 @@
+package edu.graitdm.ednajobcontroller.configuration;
+
+public interface IConfigurationDefaults {
+    String KUBECTL_PROTOCOL = "http";
+    String KUBECTL_HOST = "127.0.0.1";
+    String KUBECTL_PORT = "8080";
+    String EDNA_JOB_PATHS = "";
+    String EDNA_NAMESPACE = "default";
+
+}

--- a/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/controller/Main.java
+++ b/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/controller/Main.java
@@ -1,5 +1,7 @@
 package edu.graitdm.ednajobcontroller.controller;
 
+import com.beust.jcommander.JCommander;
+import edu.graitdm.ednajobcontroller.configuration.BaseConfiguration;
 import edu.graitdm.ednajobcontroller.controller.deployment.DeploymentController;
 import edu.graitdm.ednajobcontroller.controller.deployment.DeploymentFactory;
 import edu.graitdm.ednajobcontroller.controller.deployment.DeploymentStore;
@@ -20,7 +22,6 @@ import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.bridge.SLF4JBridgeHandler;
 
 public class Main {
     private static final Lock lock = new ReentrantLock();
@@ -67,27 +68,24 @@ public class Main {
             LOGGER = LoggerFactory.getLogger(Main.class);
             LOGGER.info("Entered Main");
 
+            BaseConfiguration configuration = new BaseConfiguration();
+            JCommander.newBuilder().addObject(configuration).build().parse(args);
+
             // Set up the namespace. This is the namespace for the EdnaJobs
             // VERY IMPORTANT -- the deployments for a job exist in a different namespace
             // All EdnaJobs exist in the default namespace
             // The generated deployments exist in a new namespace named after the application for the EdnaJob
             // We will have to create the namespace if it does not exist, by the way...
             // We will also have to delete the namespace if we delete all jobs for that application...
-            var ns = Optional.ofNullable(System.getenv("EDNAJOB_NAMESPACE")).orElse("default");
+            var ns = configuration.getEdnaNamespace();
+
 
             /*
              * Grab a new Kube client.
              */
             // TODO (Abhijit) fix this hacky workaround.
-            String url = "http://127.0.0.1:8080";
-            /*Config config = new ConfigBuilder()
-                    .withCaCertData(caCert)
-                    .withOauthToken(token)
-                    .withMasterUrl(url)
-                    .build();
-            */
-
-            var client = new DefaultKubernetesClient(url);
+            LOGGER.info(configuration.getKubectlURL());
+            var client = new DefaultKubernetesClient(configuration.getKubectlURL());
             LOGGER.info("Created Kubernetes client");
 
 

--- a/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/controller/deployment/DeploymentFactory.java
+++ b/controller/controller/src/main/java/edu/graitdm/ednajobcontroller/controller/deployment/DeploymentFactory.java
@@ -3,29 +3,19 @@ package edu.graitdm.ednajobcontroller.controller.deployment;
 import edu.graitdm.ednajobcontroller.controller.ednajob.EdnaJob;
 import edu.graitdm.ednajobcontroller.controller.ednajob.EdnaJobFactory;
 
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.LabelSelector;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.OwnerReference;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+
 import io.fabric8.kubernetes.api.model.apiextensions.CustomResourceDefinition;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
-import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.lang.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.HashMap;
 
-import static edu.graitdm.ednajobcontroller.controller.ICustomResourceCommons.EJ_API_VERSION;
+
 import static edu.graitdm.ednajobcontroller.controller.ICustomResourceCommons.EJ_APP_LABEL_KEY;
 import static edu.graitdm.ednajobcontroller.controller.ICustomResourceCommons.EJ_APP_LABEL_VALUE;
-import static edu.graitdm.ednajobcontroller.controller.ICustomResourceCommons.EJ_KIND_NAME;
 import static edu.graitdm.ednajobcontroller.controller.ICustomResourceCommons.EJ_NAME_KEY;
 
 public class DeploymentFactory {

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # EDNA
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue)](https://opensource.org/licenses/Apache-2.0)
+[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/asuprem/edna)](https://github.com/asuprem/edna/releases)
+[![Docs](https://img.shields.io/badge/docs-pdoc-brightgreen)](https://asuprem.github.io/edna/)
+
 EDNA is an end-to-end streaming toolkit for ingesting, processing, and emitting streaming data. It is based on our prior work with [LITMUS](https://ieeexplore.ieee.org/abstract/document/6971222),
 [ASSED](https://dl.acm.org/doi/abs/10.1145/3328905.3329510), and [EventMapper](https://arxiv.org/abs/2001.08700) and incorporates a slew of improvements and features for streaming analytics, fault tolerance, and end-to-end management.
 

--- a/setup/Part 8 - Custom Resource Controller/readme.md
+++ b/setup/Part 8 - Custom Resource Controller/readme.md
@@ -66,12 +66,28 @@ If using a VirtualMachine and are getting a connection error in the Java Code tr
 ```
 sudo kubectl proxy --address='0.0.0.0' --port=8080
 ```
-and change line 82 in Main.java to the IPV4 Address of your VM.
+
+and pass the IPV4 Address of your java VM as an argument when executing the script (see next section)
 
 ## Testing the code
-Now run the code with the `exec:java` configuration.
+If you need to pass arguments, you need to modify the `exec:java` configuration. The following options are current available:
 
-You can do this a couple ways, actually. You can do this through IntelliJ, or through your terminal. If you choose to use the terminal, you will need to set up the toolchain. This should be fairly straightforward, so I won't go into detail here. Baically install [openjdk11](https://www.ubuntu18.com/ubuntu-install-openjdk-11/), then install [maven](https://linuxize.com/post/how-to-install-apache-maven-on-ubuntu-18-04/#:~:text=Install%20the%20Latest%20Release%20of%20Apache%20Maven.%201,environment%20variables.%204%204.%20Verify%20the%20installation.%20) and make sure it points to the jdk installation through `JAVA_HOME`. To build in terminal you need to run `mvn clean install` from inside the `/repo/controller/controller` directory, then `mvn exec:java`.
+- `--kubectl-port` : The port for the kubectl proxy. Default is "8080"
+- `--kubectl-host` : The host for the kubectl proxy. Default is "127.0.0.1". If you are using a VM, then use the IPV4 addressof your java VM as an argument.
+- `--kubectl-protocol` : The connection protocol for the kubectl proxy. Default is "http". Replace with "https" is using "https"
+
+To pass the `--kubectl-host` argument with exec:java, you need to replace `exec:java` in IntelliJ's **Debug Configuration**'s *Command Line* with:
+
+```
+ exec:java -Dexec.args="--kubectl-host 123.4.5.6"
+```
+
+Now run the code with the `exec:java` (or `exec:java` with arguments) configuration.
+
+
+You can do this a couple ways, actually. You can do this through IntelliJ with the green triangle **run** button next to the **Debug Configurations** dropdown (or the green **debug** button), or through your terminal. 
+
+If you choose to use the terminal, you will need to set up the toolchain. This should be fairly straightforward, so I won't go into detail here. Baically install [openjdk11](https://www.ubuntu18.com/ubuntu-install-openjdk-11/), then install [maven](https://linuxize.com/post/how-to-install-apache-maven-on-ubuntu-18-04/#:~:text=Install%20the%20Latest%20Release%20of%20Apache%20Maven.%201,environment%20variables.%204%204.%20Verify%20the%20installation.%20) and make sure it points to the jdk installation through `JAVA_HOME`. To build in terminal you need to run `mvn clean install` from inside the `/repo/controller/controller` directory, then `mvn exec:java` (or `mvn exec:java -Dexec.args="--kubectl-host 123.4.5.6"`). Note -- you *might* need to use `sudo`.
 
 Once you have executed it, in the IntelliJ console or in terminal, you will get several Log messages similar to below:
 

--- a/setup/Part 8 - Custom Resource Controller/readme.md
+++ b/setup/Part 8 - Custom Resource Controller/readme.md
@@ -62,6 +62,12 @@ This is for the example applications. In the final deliverables, you will progra
 kubectl proxy --port=8080
 ```
 
+If using a VirtualMachine and are getting a connection error in the Java Code try:
+```
+sudo kubectl proxy --address='0.0.0.0' --port=8080
+```
+and change line 82 in Main.java to the IPV4 Address of your VM.
+
 ## Testing the code
 Now run the code with the `exec:java` configuration.
 


### PR DESCRIPTION
The following command line options are available:

- `--kubectl-port` : The port for the kubectl proxy. Default is "8080"
- `--kubectl-host` : The host for the kubectl proxy. Default is "127.0.0.1". If you are using a VM, then use the IPV4 addressof your java VM as an argument.
- `--kubectl-protocol` : The connection protocol for the kubectl proxy. Default is "http". Replace with "https" is using "https"

To pass the `--kubectl-host` argument, for example, with maven, 

```
mvn exec:java -Dexec.args="--kubectl-host 123.4.5.6"
```
